### PR TITLE
hive_mappers amended so that tables missing SerDeInfo will not raise …

### DIFF
--- a/heracles/handlers/hive_mappers.py
+++ b/heracles/handlers/hive_mappers.py
@@ -78,8 +78,8 @@ class HiveMappers:
             compressed=glue_table['StorageDescriptor'].get('Compressed'),
             numBuckets=glue_table['StorageDescriptor'].get('NumberOfBuckets', -1),
             serdeInfo=ttypes.SerDeInfo(
-                serializationLib=glue_table['StorageDescriptor']['SerdeInfo']['SerializationLibrary'],
-                parameters=glue_table['StorageDescriptor']['SerdeInfo']['Parameters'],
+                serializationLib=glue_table['StorageDescriptor'].get('SerdeInfo', {}).get('SerializationLibrary'),
+                parameters=glue_table['StorageDescriptor'].get('SerdeInfo', {}).get('Parameters'),
             ),
             bucketCols=glue_table['StorageDescriptor'].get('BucketColumns', []),
             sortCols=glue_table['StorageDescriptor'].get('SortColumns', []),
@@ -122,8 +122,8 @@ class HiveMappers:
             compressed=glue_partition['StorageDescriptor'].get('Compressed'),
             numBuckets=glue_partition['StorageDescriptor'].get('NumberOfBuckets', -1),
             serdeInfo=ttypes.SerDeInfo(
-                serializationLib=glue_partition['StorageDescriptor']['SerdeInfo']['SerializationLibrary'],
-                parameters=glue_partition['StorageDescriptor']['SerdeInfo']['Parameters'],
+                serializationLib=glue_partition['StorageDescriptor'].get('SerdeInfo', {}).get('SerializationLibrary'),
+                parameters=glue_partition['StorageDescriptor'].get('SerdeInfo', {}).get('Parameters'),
             ),
             bucketCols=glue_partition['StorageDescriptor'].get('BucketColumns', []),
             sortCols=glue_partition['StorageDescriptor'].get('SortColumns', []),

--- a/test/test_getters.py
+++ b/test/test_getters.py
@@ -16,28 +16,28 @@ def test_get_all_databases(mocker):
     responses = [build_db_response("test_{}".format(i)) for i in range(10)]
     glue_stub.add_response_for_method('get_databases', {'DatabaseList': responses}, {})
 
-    with mocker.patch('boto3.client', return_value=glue_stub.client):
-        with glue_stub.stubber:
-            response = GetAllDatabases().execute({})
-            assert len(response['databases']) == 10
+    mocker.patch('boto3.client', return_value=glue_stub.client)
+    with glue_stub.stubber:
+        response = GetAllDatabases().execute({})
+        assert len(response['databases']) == 10
 
 
 def test_get_database(mocker):
     glue_stub = GlueStubber()
     single_db = build_db_response("test_single")
     glue_stub.add_response_for_method('get_database', {'Database': single_db}, {'Name': 'test_single'})
-    with mocker.patch('boto3.client', return_value=glue_stub.client):
-        with glue_stub.stubber:
-            response = GetDatabase().execute({'dbName': 'test_single'})
-            # The result is a JSONThrift-encoded string, so we just make sure the database name is there
-            assert '"test_single"' in response['database']
+    mocker.patch('boto3.client', return_value=glue_stub.client)
+    with glue_stub.stubber:
+        response = GetDatabase().execute({'dbName': 'test_single'})
+        # The result is a JSONThrift-encoded string, so we just make sure the database name is there
+        assert '"test_single"' in response['database']
 
-            # Getting a non-existing database raises an error
-            glue_stub.add_error_for_method('get_database', 'EntityNotFoundException', ' Database notadb not found.', 404, {'Name': 'notadb'})
-            with pytest.raises(ClientError) as excinfo:
-                print("WHAT")
-                response = GetDatabase().execute({'dbName': 'notadb'})
-            assert str(excinfo.value) == 'An error occurred (EntityNotFoundException) when calling the GetDatabase operation:  Database notadb not found.'
+        # Getting a non-existing database raises an error
+        glue_stub.add_error_for_method('get_database', 'EntityNotFoundException', ' Database notadb not found.', 404, {'Name': 'notadb'})
+        with pytest.raises(ClientError) as excinfo:
+            print("WHAT")
+            response = GetDatabase().execute({'dbName': 'notadb'})
+        assert str(excinfo.value) == 'An error occurred (EntityNotFoundException) when calling the GetDatabase operation:  Database notadb not found.'
 
 
 def test_get_all_tables(mocker):
@@ -46,11 +46,11 @@ def test_get_all_tables(mocker):
     responses = [build_table_response(database_name, "test_{}".format(i), [], ["a", "b"]) for i in range(10)]
     glue_stub.add_response_for_method('get_tables', {'TableList': responses}, {'DatabaseName': database_name, 'Expression': '.*'})
 
-    with mocker.patch('boto3.client', return_value=glue_stub.client):
-        with glue_stub.stubber:
-            response = GetAllTables().execute({'dbName': database_name})
-            assert len(response['tables']) == 10
-            assert response['tables'][0] == 'test_0'
+    mocker.patch('boto3.client', return_value=glue_stub.client)
+    with glue_stub.stubber:
+        response = GetAllTables().execute({'dbName': database_name})
+        assert len(response['tables']) == 10
+        assert response['tables'][0] == 'test_0'
 
 
 def test_get_table(mocker):
@@ -60,10 +60,10 @@ def test_get_table(mocker):
     responses = build_table_response(database_name, table_name, [], ["a", "b"])
     glue_stub.add_response_for_method('get_table', {'Table': responses}, {'DatabaseName': database_name, 'Name': table_name})
 
-    with mocker.patch('boto3.client', return_value=glue_stub.client):
-        with glue_stub.stubber:
-            response = GetTable().execute({'dbName': database_name, 'tableName': table_name})
-            assert 'tableDesc' in response
-            print(response)
-            assert '"{}"'.format(table_name) in response['tableDesc']
-            assert '"{}"'.format(database_name) in response['tableDesc']
+    mocker.patch('boto3.client', return_value=glue_stub.client)
+    with glue_stub.stubber:
+        response = GetTable().execute({'dbName': database_name, 'tableName': table_name})
+        assert 'tableDesc' in response
+        print(response)
+        assert '"{}"'.format(table_name) in response['tableDesc']
+        assert '"{}"'.format(database_name) in response['tableDesc']

--- a/test/test_glue_client.py
+++ b/test/test_glue_client.py
@@ -14,11 +14,11 @@ def test_get_all_databases_onecall(mocker):
     responses = [build_db_response("test_{}".format(i)) for i in range(10)]
     glue_stub.add_response_for_method('get_databases', {'DatabaseList': responses}, {})
 
-    with mocker.patch('boto3.client', return_value=glue_stub.client):
-        with glue_stub.stubber:
-            test_resp = GlueClient().get_all_database_names()
-            assert len(test_resp) == len(responses)
-            assert all(['test_' in name for name in test_resp])
+    mocker.patch('boto3.client', return_value=glue_stub.client)
+    with glue_stub.stubber:
+        test_resp = GlueClient().get_all_database_names()
+        assert len(test_resp) == len(responses)
+        assert all(['test_' in name for name in test_resp])
 
 
 def test_get_all_databases_pagination(mocker):
@@ -28,8 +28,8 @@ def test_get_all_databases_pagination(mocker):
     glue_stub.add_response_for_method('get_databases', {'DatabaseList': responses, 'NextToken': next_token}, {})
     glue_stub.add_response_for_method('get_databases', {'DatabaseList': responses}, {'NextToken': next_token})
 
-    with mocker.patch('boto3.client', return_value=glue_stub.client):
-        with glue_stub.stubber:
-            test_resp = GlueClient().get_all_database_names()
-            assert len(test_resp) == len(responses)*2
-            assert all(['test_' in name for name in test_resp])
+    mocker.patch('boto3.client', return_value=glue_stub.client)
+    with glue_stub.stubber:
+        test_resp = GlueClient().get_all_database_names()
+        assert len(test_resp) == len(responses)*2
+        assert all(['test_' in name for name in test_resp])


### PR DESCRIPTION
…an exception.

Amended unit tests to ensure correct running (pytest does not permit mocker to be used as a context manager)